### PR TITLE
make: fix typo for test_images repo

### DIFF
--- a/ContainerMakefile
+++ b/ContainerMakefile
@@ -31,15 +31,15 @@ lint: ## TODO: with hadolint or similar
 .PHONY: build
 build: ## build container with the current Dockerfile
 	$(call title,Building container image anchore/test_image:$(NAME))
-	docker build -t anchore/test_image:$(NAME) .
+	docker build -t anchore/test_images:$(NAME) .
 
 .PHONY: push
 push: ## push built container to Docker Hub
 	$(call title,Pushing container image to docker hub anchore/test_image:$(NAME))
 	docker build -t anchore/test_image:$(NAME) .
-	docker push anchore/test_image:$(NAME)
+	docker push anchore/test_images:$(NAME)
 
 .PHONY: clean
 clean: ## Remove images with the assigned tag for test_images
 	$(call title,Removing image anchore/test_image:$(NAME))
-	docker rmi anchore/test_image:$(NAME)
+	docker rmi anchore/test_images:$(NAME)


### PR DESCRIPTION
The typo was (of course) preventing pushing images to docker hub.