### PR TITLE
create a helper for local images only from the parent dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ all: build
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(BOLD)$(CYAN)%-25s$(RESET)%s\n", $$1, $$2}'
+	@for dir in $(shell ls containers); do \
+		printf "$(BOLD)$(CYAN)%-25s$(RESET)Create the local %s container\n" $$dir $$dir; \
+	done
 
 
 .PHONY: lint
@@ -61,3 +64,6 @@ link_check: ## Make sure that all symlinks are correct
 		if [[ $$(readlink $${makefile}) != "../../ContainerMakefile" ]]; then echo "Path is not linked to ../../ContainerMakefile -> $${makefile}" && exit 1; fi; \
 		echo "	[OK]"; \
 	done
+
+%: ## do a local build
+	scripts/local.sh "$*"

--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ A couple of other `make` commands are available for the symlinked `Makefile`, th
 * `make build`: builds the current container locally, tags it with the current directory name
 * `make clean`: Removes the container image associated with the directory. If the directory name is `new`, then it will try to remove `anchore/test_images:new`
 * `make lint`: Runs the `hadolint/hadolint` container passing the contents of the `Dockerfile` to stdin, this step is run as a verification when a PR is opened
+
+In addition to defined targets, the `Makefile` supports dynamic targets by looking into the `containers/` directory. Every sub-directory in that path becomes an available target to build it locally. For example, `containers/py38` is exposed and available with the following command:
+
+```
+$ make py38
+```

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script is only meant to run from Makefile in the parent directory of this repository
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied, this command requires an image tag to build, like:"
+    for directory in  $(ls "$SCRIPTPATH/../containers"); do
+	echo "- $directory"
+    done
+    exit 1
+fi
+
+CONTAINER=$1
+
+cd "$SCRIPTPATH/../containers/$CONTAINER"
+if [ $? != 0 ]; then
+	echo "$CONTAINER is not a Makefile target or container to build. If trying to build a container locally"
+	echo "then it must be one of:"
+	for directory in  $(ls "$SCRIPTPATH/../containers"); do
+		echo "- $directory"
+	done
+	echo ""
+	echo "For other Makefile targets use:"
+	echo "    make help"
+	echo ""
+	exit 2
+fi
+
+make build


### PR DESCRIPTION
This allows (from the parent dir) to do:

```
$ make py38
Building container image anchore/test_image:py38
docker build -t anchore/test_images:py38 .
[+] Building 1.0s (6/6) FINISHED
 => [internal] load .dockerignore                                                                                                                             0.4s
 => => transferring context: 2B                                                                                                                               0.0s
 => [internal] load build definition from Dockerfile                                                                                                          0.4s
 => => transferring dockerfile: 661B                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.6s
 => [1/2] FROM docker.io/library/alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                               0.0s
 => CACHED [2/2] RUN set -ex &&     apk add --no-cache python3=3.8.5-r0 &&     python3 -m ensurepip &&     pip3 install pytest==6.1.1 &&     rm -rf /var/cac  0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:61aebaf443785820a5fb09905d2157a95550f46987532b9f895317437ffd2db9                                                                  0.0s
 => => naming to docker.io/anchore/test_images:py38                                                                                                           0.0s
```

And expands targets in the parent Makefile to accept containers:

```
$  make help
build                    Create all containers in the containers sub directory
link_check               Make sure that all symlinks are correct
lint                     Uses hadolint container to ensure Dockerfiles are clean
push                     Create all containers and push them to docker hub
test                     Lint first, and then build all containers
gems                     Create the local gems container
npm                      Create the local npm container
py38                     Create the local py38 container
```