### PR TITLE
make: use the build target before pushing

### DIFF
--- a/ContainerMakefile
+++ b/ContainerMakefile
@@ -39,9 +39,8 @@ endif
 	docker build -t anchore/test_images:$(NAME) .
 
 .PHONY: push
-push: ## push built container to Docker Hub
+push: build ## push built container to Docker Hub
 	$(call title,Pushing container image to docker hub anchore/test_image:$(NAME))
-	docker build -t anchore/test_images:$(NAME) .
 	docker push anchore/test_images:$(NAME)
 
 .PHONY: clean


### PR DESCRIPTION
As explained in #15, we need to call the optional `setup.sh` scripts. Instead of `ifdef` this PR re-uses the `build` target before pushing.

Closes #15 