### PR TITLE
Add ownership overlap image

### DIFF
--- a/containers/ownership-overlap/Dockerfile
+++ b/containers/ownership-overlap/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:20.04
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y python-pil=6.2.1-3 --no-install-recommends ; \
+    rm -rf /var/lib/apt/lists/*

--- a/containers/ownership-overlap/Makefile
+++ b/containers/ownership-overlap/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/ownership-overlap/README.md
+++ b/containers/ownership-overlap/README.md
@@ -1,0 +1,4 @@
+# `ownership-overlap`
+This is an image that has one package owned by another package. In this case an RPM (python-pil) that "owns" the installed python package "Pillow".
+
+Syft should mark this relationship while engine should deduplicate these (preferring parent packages).


### PR DESCRIPTION
The new image adds an image with an RPM package which "owns" a python package.