### PR TITLE
Vulnerability types

### DIFF
--- a/containers/bin/Dockerfile
+++ b/containers/bin/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.12.3
 # python2                       2.7.18-r0               custom
 # python3                       3.8.5-r0                PSF-2.0
 # ...
-RUN apk add --no-cache go=1.13.15-r0 python3=3.8.5-r1 python2=2.7.18-r0 busybox=1.31.1-r19
+RUN apk add --no-cache go=1.13.15-r0 python3=3.8.8-r0 python2=2.7.18-r0 busybox=1.31.1-r19
 
 # place the test fixtures (including positive and negative examples)
 #

--- a/containers/gems/Dockerfile
+++ b/containers/gems/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex && \
     apk --no-cache add ruby=2.7.2-r3 ruby-dev=2.7.2-r3 && \
     gem install bundler:2.1.4 && \
 # install python, pip,  and pytest \
-    apk add --no-cache python3=3.8.7-r1 && \
+    apk add --no-cache python3=3.8.8-r0 && \
     python3 -m ensurepip && \
     pip3 install --no-cache-dir pytest==6.1.1 && \
     rm -rf /var/cache/apk/* && \

--- a/containers/java/Dockerfile
+++ b/containers/java/Dockerfile
@@ -1,8 +1,8 @@
 # hadolint ignore=DL3006
 FROM alpine
 
-RUN wget https://repo1.maven.org/maven2/junit/junit/4.13.1/junit-4.13.1.jar && \
-    wget https://get.jenkins.io/plugins/TwilioNotifier/0.2.1/TwilioNotifier.hpi && \
-    wget https://updates.jenkins-ci.org/download/war/1.390/hudson.war
+RUN wget -nv https://repo1.maven.org/maven2/junit/junit/4.13.1/junit-4.13.1.jar && \
+    wget -nv https://get.jenkins.io/plugins/TwilioNotifier/0.2.1/TwilioNotifier.hpi && \
+    wget -nv https://updates.jenkins-ci.org/download/war/1.390/hudson.war
 
 COPY build/example-java-app-gradle-0.1.0.ear /

--- a/containers/py38/Dockerfile
+++ b/containers/py38/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine
 # finally it removes the cache - all in one go to prevent another layer which we don't need
 RUN set -ex && \
 # install python, pip,  and pytest \
-    apk add --no-cache python3=3.8.7-r1 && \
+    apk add --no-cache python3=3.8.8-r0 && \
     python3 -m ensurepip && \
     pip3 install --no-cache-dir pytest==6.1.1 && \
     rm -rf /var/cache/apk/* && \

--- a/containers/vulnerabilities-alpine/Dockerfile
+++ b/containers/vulnerabilities-alpine/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine@sha256:d1eaae2a6814b4b10a722fa75e8a6b53db42d1bf531395a107fea0458bfbf1d8
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+# install ruby, python, java, and nodejs 
+# now install packages using GEM, NPM, PIP, and Java
+
+RUN set -ex && \
+    apk --no-cache add ruby=2.7.2-r0 && \
+    apk --no-cache add gcc=9.3.0-r2 musl-dev=1.1.24-r10 && \
+    apk --no-cache add python3=3.8.8-r0 python3-dev=3.8.8-r0 && \
+    python3 -m ensurepip && \
+    apk --no-cache add openjdk11=11.0.9_p11-r0  maven=3.6.3-r0 && \
+    apk --no-cache add nodejs=12.21.0-r0 npm=12.21.0-r0 && \
+    gem install ftpd -v 0.2.1 && \
+    npm install xmldom@0.4.0 && \
+    pip3 install --no-cache-dir aiohttp==3.7.3 && \
+    mvn clean install && mvn package && \
+    apk --no-cache del ruby gcc musl-dev python3 python3-dev openjdk11 maven nodejs npm && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /root/.m2

--- a/containers/vulnerabilities-alpine/Makefile
+++ b/containers/vulnerabilities-alpine/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-alpine/README.md
+++ b/containers/vulnerabilities-alpine/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-alpine`
+An Alpine base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-alpine/pom.xml
+++ b/containers/vulnerabilities-alpine/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/containers/vulnerabilities-centos/Dockerfile
+++ b/containers/vulnerabilities-centos/Dockerfile
@@ -1,0 +1,23 @@
+# hadolint ignore=DL3006
+FROM centos@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+# hadolint ignore=DL3015
+RUN yum install ruby-2.0.0.648 -y && \
+yum install gcc-4.8.5 python3-devel-3.6.8 -y && \
+yum install python3-3.6.8 python3-pip-9.0.3 -y && \
+yum install java-11-openjdk-11.0.10.0.9 maven-3.0.5 -y && \
+yum install epel-release-7 -y && \
+yum install nodejs-6.17.1 -y && \
+gem install ftpd -v 0.2.1 && \
+npm install xmldom@0.4.0 && \
+pip3 install --no-cache-dir aiohttp==3.7.3 && \
+mvn clean install && mvn package && \
+yum remove ruby gcc python3-devel python3-pip python3 java-11-openjdk maven nodejs epel-release -y && \
+yum autoremove -y && \
+yum clean all && \
+rm -rf /var/cache/yum && \
+rm -rf /root/.m2

--- a/containers/vulnerabilities-centos/Makefile
+++ b/containers/vulnerabilities-centos/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-centos/README.md
+++ b/containers/vulnerabilities-centos/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-centos`
+A CentOS base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-centos/pom.xml
+++ b/containers/vulnerabilities-centos/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/containers/vulnerabilities-debian/Dockerfile
+++ b/containers/vulnerabilities-debian/Dockerfile
@@ -1,0 +1,25 @@
+# hadolint ignore=DL3006
+FROM debian@sha256:ca9003e9899b458d46b6ee6b040cf9e0d715acbc58e0615871f019c38ada8bc1
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+# hadolint ignore=DL3015
+RUN apt-get update && \
+    apt-get install -y ruby-full=1:2.5.1 && \
+    apt-get install -y python3=3.7.3-1 && \
+    apt-get -y install python3-pip=18.1-5  && \
+    mkdir -p /usr/share/man/man1 && \
+    apt-get install -y openjdk-11-jdk=11.0.9.1+1-1~deb10u2  && \
+    apt-get install -y maven=3.6.0-1 && \
+    apt-get install -y nodejs=10.24.0~dfsg-1~deb10u1 npm=5.8.0+ds6-4+deb10u2 && \
+    gem install ftpd -v 0.2.1 && \
+    npm install xmldom@0.4.0 && \
+    pip3 install --no-cache-dir aiohttp==3.7.3 && \
+    mvn clean install && mvn package  && \
+    apt-get remove -y ruby-full python3 python3-pip npm nodejs openjdk-11-jdk maven && \
+    apt-get autoremove -y && \
+    rm -rf /root/.m2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/containers/vulnerabilities-debian/Makefile
+++ b/containers/vulnerabilities-debian/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-debian/README.md
+++ b/containers/vulnerabilities-debian/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-debian`
+A Debian base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-debian/pom.xml
+++ b/containers/vulnerabilities-debian/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Creates new test images for three OSes with different package managers. These images are designed to recreate 4 specific CVEs.

OSes:
* Alpine
* Debian
* CentOS

Packages Installed:
* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
