### PR TITLE
unique tags for test image versions

### DIFF
--- a/ContainerMakefile
+++ b/ContainerMakefile
@@ -1,4 +1,5 @@
-NAME := $(shell pwd | rev | cut -d '/' -f 1 | rev)
+LAST_COMMIT := $(shell git rev-parse HEAD | cut -c 1-7)
+NAME := $(shell pwd | rev | cut -d '/' -f 1 | rev)-$(LAST_COMMIT)
 TEMPDIR = ./.tmp
 IMAGEDIRS = $(shell ls -d containers/* | cut -d '/' -f 2)
 BOLD := $(shell tput -T linux bold)


### PR DESCRIPTION
Build failures happen whenever Alpine deprecates APKs. Fixing the build failures makes our images change.
It's normal to have images change over time, but for tests, we sometimes want to have a consistently identifiable image with specific software versions.
The solution? Image versions and new tags for new images. Append first 7 of current commit sha to the docker tag. This way we can easily trace an image back to its dockerfile version.

Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>