### PR TITLE
add image for testing engine analyzer on go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /usr/bin/env bash
-IMAGEDIRS = $(shell ls -d containers/* | cut -d '/' -f 2)
+BASEBRANCH := main
+CHANGEDCONTAINERDIRS := $(shell git diff $(BASEBRANCH) --name-only containers/ | cut -d '/' -f1,2 | uniq)
 BOLD := $(shell tput -T linux bold)
 PURPLE := $(shell tput -T linux setaf 5)
 GREEN := $(shell tput -T linux setaf 2)
@@ -27,7 +28,7 @@ help:
 
 .PHONY: lint
 lint: ## Uses hadolint container to ensure Dockerfiles are clean
-	@for dir in $(shell ls -d containers/*); do \
+	@for dir in $(CHANGEDCONTAINERDIRS); do \
 		echo "Linting container: $${dir}"; \
 		pushd $${dir} || exit 1; \
 		make lint || exit 1; \
@@ -41,7 +42,7 @@ test: build link_check ## Lint first, and then build all containers
 
 .PHONY: build
 build: ## Create all containers in the containers sub directory
-	@for dir in $(shell ls -d containers/*); do \
+	@for dir in $(CHANGEDCONTAINERDIRS); do \
 		echo "Building container: $${dir}"; \
 		pushd $${dir} || exit 1; \
 		make build || exit 1; \
@@ -50,7 +51,7 @@ build: ## Create all containers in the containers sub directory
 
 .PHONY: push
 push: ## Create all containers and push them to docker hub
-	@for dir in $(shell ls -d containers/*); do \
+	@for dir in $(CHANGEDCONTAINERDIRS); do \
 		echo "Pushing container: $${dir}"; \
 		pushd $${dir} || exit 1; \
 		make push || exit 1; \

--- a/containers/engine-analyzer-golang/Dockerfile
+++ b/containers/engine-analyzer-golang/Dockerfile
@@ -1,0 +1,18 @@
+# hadolint ignore=DL3006
+FROM docker.io/alpine:3.15.0 as go-src
+
+WORKDIR /go/src
+
+RUN apk add --no-cache git="2.34.1-r0" && \
+    git clone --depth 1 --branch "v0.32.0" https://github.com/anchore/grype && \
+    git clone --depth 1 --branch "v0.36.0" https://github.com/anchore/syft
+
+FROM docker.io/anchore/grype:v0.32.0 as grype-binary
+FROM docker.io/anchore/syft:v0.36.0 as syft-binary
+FROM scratch
+
+COPY --from=go-src /go/src/grype/go.mod /go/src/grype/
+COPY --from=go-src /go/src/syft/go.mod /go/src/syft/
+
+COPY --from=grype-binary /grype /usr/local/bin/
+COPY --from=syft-binary /syft /usr/local/bin/

--- a/containers/engine-analyzer-golang/Makefile
+++ b/containers/engine-analyzer-golang/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/engine-analyzer-golang/README.md
+++ b/containers/engine-analyzer-golang/README.md
@@ -1,0 +1,4 @@
+# `engine-analyzer-golang`
+A from scratch image with a go binary and a go project with go.mod file.  When performing container scanning the go.mod file scanning is disabled.
+
+Used in analyzer tests.


### PR DESCRIPTION
Adds an image to use for functional testing of engine analyzer to detect go dependencies.  It also modifies the CI process to only build images with changes so we hopefully won't have to deal with broken builds of previous images just to merge new ones.

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>