### PR TITLE
add policy-engine vulnerability scanner test images covering more distros

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8.4
     environment: *global_environment_vars
     steps:
       - setup_remote_docker:
@@ -58,7 +58,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8.4
     environment: *global_environment_vars
     steps:
       - setup_remote_docker:
@@ -71,7 +71,7 @@ jobs:
   push:
     description: Uses make script to push images to DockerHub
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8.4
     environment: *global_environment_vars
     steps:
       - setup_remote_docker:

--- a/containers/vulnerabilities-amazonlinux-2/Dockerfile
+++ b/containers/vulnerabilities-amazonlinux-2/Dockerfile
@@ -1,0 +1,22 @@
+# amazonlinux:2.0.20210126.0
+FROM amazonlinux@sha256:3c663506cf84b035d68c6450c48f76092821736d6b0615d8bd45f3caf525abe7
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+# hadolint ignore=DL3015,DL4006
+RUN curl -fsSL https://rpm.nodesource.com/setup_12.x | bash - && \ 
+yum install ruby-2.0.0.648 -y && \
+yum install gcc-7.3.1-5.amzn2.0.2 python-3-devel-3.7.0-0.20.rc1.amzn2.0.2 -y && \
+yum install python3-3.7.0-0.20.rc1.amzn2.0.2 python3-pip-20.2.2-1.amzn2.0.3 -y && \
+yum install java-1.8.0-openjdk-1.8.0.222.b03-1.amzn2.0.1 maven-3.0.5-17.amzn2 -y && \
+yum install nodejs-12.22.12-1nodesource -y && \
+gem install ftpd -v 0.2.1 && \
+npm install xmldom@0.4.0 && \
+pip3 install --no-cache-dir aiohttp==3.7.3 && \
+mvn clean install && mvn package && \
+yum remove ruby gcc python3-devel python3-pip python3 java-1.8.0-openjdk maven nodejs -y && \
+yum clean all && \
+rm -rf /var/cache/yum && \
+rm -rf /root/.m2

--- a/containers/vulnerabilities-amazonlinux-2/Makefile
+++ b/containers/vulnerabilities-amazonlinux-2/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-amazonlinux-2/README.md
+++ b/containers/vulnerabilities-amazonlinux-2/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-amazonlinux-2`
+An Amazon Linux 2 base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-amazonlinux-2/pom.xml
+++ b/containers/vulnerabilities-amazonlinux-2/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/containers/vulnerabilities-oraclelinux-7/Dockerfile
+++ b/containers/vulnerabilities-oraclelinux-7/Dockerfile
@@ -1,0 +1,27 @@
+# hadolint ignore=DL3006
+# oraclelinux:7-slim
+FROM oraclelinux@sha256:8e23381802e207aa9dee2e27ee85812f645735e2572482f52ab767de60b29126
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64/jre
+
+# hadolint ignore=DL3015,DL4006
+RUN yum install wget-1.14-18.el7_6.1 -y && \
+wget --quiet http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo && \
+yum install ruby-2.0.0.648-39.el7_9 -y && \
+yum install gcc-4.8.5-28.0.1.el7 python3-devel-3.6.8-18.0.5.el7 -y && \
+yum install python3-3.6.8-18.0.5.el7 python3-pip-9.0.3-8.0.1.el7 -y && \
+yum install apache-maven-3.5.2-1.el7 -y && \
+yum install oracle-nodejs-release-el7-1.0-9.el7 -y && \
+yum install nodejs-16.14.2-1.0.1.el7 -y && \
+gem install ftpd -v 0.2.1 && \
+npm install xmldom@0.4.0 && \
+pip3 install --no-cache-dir aiohttp==3.7.3 && \
+mvn clean install && mvn package && \
+yum remove ruby gcc python3-devel python3-pip python3 java-11-openjdk maven nodejs wget oracle-nodejs-release-el7 -y && \
+yum clean all && \
+rm -rf /var/cache/yum && \
+rm -rf /root/.m2

--- a/containers/vulnerabilities-oraclelinux-7/Makefile
+++ b/containers/vulnerabilities-oraclelinux-7/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-oraclelinux-7/README.md
+++ b/containers/vulnerabilities-oraclelinux-7/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-oraclelinux`
+An Oracle Linux 7 base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-oraclelinux-7/pom.xml
+++ b/containers/vulnerabilities-oraclelinux-7/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/containers/vulnerabilities-ubuntu-18.04/Dockerfile
+++ b/containers/vulnerabilities-ubuntu-18.04/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu@sha256:86361bc18dd2964b8dc5971c82bf6c75b8515eb2dbfe879b76c5b149e8ca158a
+
+WORKDIR /sandbox
+
+COPY ./pom.xml pom.xml
+
+RUN apt-get update && \
+    apt-get install -y ruby-full=1:2.5.1 --no-install-recommends && \
+    apt-get install -y python3.7=3.7.5-2ubuntu1~18.04.2 --no-install-recommends && \
+    apt-get -y install python3-pip=9.0.1-2.3~ubuntu1.18.04.5 python3-setuptools=39.0.1-2 python3-wheel=0.30.0-0.2 --no-install-recommends  && \
+    mkdir -p /usr/share/man/man1 && \
+    apt-get install -y openjdk-11-jdk=11.0.15+10-0ubuntu0.18.04.1 --no-install-recommends  && \
+    apt-get install -y maven=3.6.0-1~18.04.1 --no-install-recommends && \
+    apt-get install -y nodejs=8.10.0~dfsg-2ubuntu0.4 npm=3.5.2-0ubuntu4 --no-install-recommends && \
+    gem install ftpd -v 0.2.1 && \
+    npm install xmldom@0.4.0 && \
+    pip3 install --no-cache-dir aiohttp==3.7.3 && \
+    mvn clean install && mvn package  && \
+    apt-get remove -y ruby-full python3.7 python3-pip npm nodejs openjdk-11-jdk maven && \
+    apt-get autoremove -y && \
+    rm -rf /root/.m2 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/containers/vulnerabilities-ubuntu-18.04/Makefile
+++ b/containers/vulnerabilities-ubuntu-18.04/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile

--- a/containers/vulnerabilities-ubuntu-18.04/README.md
+++ b/containers/vulnerabilities-ubuntu-18.04/README.md
@@ -1,0 +1,10 @@
+# `vulnerabilities-ubuntu`
+An Ubuntu 18.04 base image with openjdk 11, python 3.8, ruby 2.7.2, and nodejs 12.21. 
+Includes the following packages:
+
+* ftpd 0.2.1 (gem) [CVE-2013-2512](https://nvd.nist.gov/vuln/detail/CVE-2013-2512)
+* xmldom 0.5.0 (npm) [CVE-2021-21366](https://nvd.nist.gov/vuln/detail/CVE-2021-21366)
+* aiohttp 3.7.3 (python) [CVE-2021-21330](https://nvd.nist.gov/vuln/detail/CVE-2021-21330)
+* guava 23.0 (java) [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908)
+
+Used in policy engine tests.

--- a/containers/vulnerabilities-ubuntu-18.04/pom.xml
+++ b/containers/vulnerabilities-ubuntu-18.04/pom.xml
@@ -1,0 +1,37 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Adds images for use in the enterprise policy engine vulnerability scanner functional tests for the following:
- Ubuntu
- Amazon Linux 2
- Oracle Linux

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>