### PR TITLE
chore: update syft-bin image python binary test fixtures

### DIFF
--- a/containers/syft_bin/Dockerfile
+++ b/containers/syft_bin/Dockerfile
@@ -1,3 +1,6 @@
+FROM python:3.11-slim@sha256:0b106e1d2bf485c2a41474bc9cd5103e9eea4e179f40f10741b53b127059221e as python-3.11-slim
+FROM registry.access.redhat.com/ubi8/python-39@sha256:f3cf958b96ce016b63e3e163e488f52e42891304dafef5a0811563f22e3cbad0 as python-3.9-ubi8
+FROM python:3.9.16-bullseye@sha256:93fb93c461a2e47a2176706fad1f39eaacd5dd40e19c0b018699a28c03eb2e2a as python-3.9-bullseye
 FROM alpine:3.12.3
 
 # install go 1.13, python 3.8, and busybox 1.31
@@ -47,3 +50,13 @@ RUN mkdir /staged/copy && \
     cp "$(which python3.8)" /staged/copy && \
     cp /usr/lib/libpython2.7.so.1.0 /staged/copy && \
     cp "$(which busybox)" /staged/copy
+
+
+# Taken from updated syft test fixtures at https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/binary/test-fixtures/Makefile
+COPY --from=python-3.11-slim /usr/local/bin/python3.11 /usr/local/bin/python3
+COPY --from=python-3.11-slim /usr/local/lib/libpython3.11.so.1.0 /usr/local/lib/libpython3.11.so.1.0
+
+COPY --from=python-3.9-ubi8 /usr/bin/python3.9 /usr/bin/python3.9
+COPY --from=python-3.9-ubi8 /usr/lib64/libpython3.9.so.1.0 /usr/lib64/libpython3.9.so.1.0
+
+COPY --from=python-3.9-bullseye /usr/bin/python3.9 /usr/bin/python3.9

--- a/containers/syft_bin/staged/positive/libpython3.7.so
+++ b/containers/syft_bin/staged/positive/libpython3.7.so
@@ -1,2 +1,0 @@
-# note: this SHOULD match as python 3.7
-noise3.7.4a-vZ9!morenoise

--- a/containers/syft_bin/staged/positive/patchlevel.h
+++ b/containers/syft_bin/staged/positive/patchlevel.h
@@ -1,7 +1,0 @@
-# note: this SHOULD match as python 3.9
-
-some source code...
-
-#define    PY_VERSION   3.9-aZ5
-
-more source!

--- a/containers/syft_bin/staged/positive/python3.6
+++ b/containers/syft_bin/staged/positive/python3.6
@@ -1,3 +1,0 @@
-# note: this SHOULD match as python 3.6
-
-noise3.6.3a-vZ9!morenoise


### PR DESCRIPTION
Updates the syft_bin test image to use the latest python binary test fixtures post https://github.com/anchore/syft/pull/1648