### PR TITLE
Add multi-arch image for testing stereoscope

### DIFF
--- a/containers/multi-arch-stereoscope-tests/Dockerfile
+++ b/containers/multi-arch-stereoscope-tests/Dockerfile
@@ -1,5 +1,4 @@
-ARG ARCH=
-FROM --platform=${ARCH} busybox:1.36.1-musl
+FROM --platform=${TARGETPLATFORM} busybox:1.36.1-musl
 
 ENTRYPOINT [ "echo" ]
 

--- a/containers/multi-arch-stereoscope-tests/Dockerfile
+++ b/containers/multi-arch-stereoscope-tests/Dockerfile
@@ -1,0 +1,5 @@
+ARG ARCH=
+FROM --platform=${ARCH} busybox:1.36.1-musl
+
+ENTRYPOINT [ "echo" ]
+

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -23,9 +23,9 @@ lint:
 .PHONY: build
 build:
 	$(call title,Building container image anchore/test_image:$(NAME) variants)
-	docker build -t anchore/test-images:$(NAME)-amd64-only --build-arg ARCH=linux/amd64 .
-	docker build -t anchore/test-images:$(NAME)-s390x-only --build-arg ARCH=linux/s390x .
-	docker build -t anchore/test-images:$(NAME)-arm64-only --build-arg ARCH=linux/arm64 .
+	docker build -t anchore/test-images:$(NAME)-amd64-only --platform=linux/amd64 .
+	docker build -t anchore/test-images:$(NAME)-s390x-only --platform=linux/s390x .
+	docker build -t anchore/test-images:$(NAME)-arm64-only --platform=linux/arm64 .
 
 .PHONY: push
 push: build ## push built container to Docker Hub

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -34,15 +34,15 @@ push: build ## push built container to Docker Hub
 	docker push anchore/test-images:$(NAME)-s390x-only
 	docker push anchore/test-images:$(NAME)-arm64-only
 	docker manifest create \
-	anchore/test-images\:$(NAME)-no-arm64 \
-	--amend anchore/test-images\:$(NAME)-amd64-only \
-	--amend anchore/test-images\:$(NAME)-s390x-only
-	docker push anchore/test-images\:$(NAME)-no-arm64
+	anchore/test-images:$(NAME)-no-arm64 \
+	--amend anchore/test-images:$(NAME)-amd64-only \
+	--amend anchore/test-images:$(NAME)-s390x-only
+	docker push anchore/test-images:$(NAME)-no-arm64
 	docker manifest create \
-	anchore/test-images\:$(NAME)-no-amd64 \
-	--amend anchore/test-images\:$(NAME)-s390x-only \
-	--amend anchore/test-images\:$(NAME)-arm64-only
-	docker push anchore/test-images\:$(NAME)-no-amd64
+	anchore/test-images:$(NAME)-no-amd64 \
+	--amend anchore/test-images:$(NAME)-s390x-only \
+	--amend anchore/test-images:$(NAME)-arm64-only
+	docker push anchore/test-images:$(NAME)-no-amd64
 
 .PHONY: clean
 clean: ## Remove images with the assigned tag for test_images

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -37,12 +37,12 @@ push: build ## push built container to Docker Hub
 	anchore/test-images:$(NAME)-no-arm64 \
 	--amend anchore/test-images:$(NAME)-amd64-only \
 	--amend anchore/test-images:$(NAME)-s390x-only
-	docker push anchore/test-images:$(NAME)-no-arm64
+	docker manifest push anchore/test-images:$(NAME)-no-arm64
 	docker manifest create \
 	anchore/test-images:$(NAME)-no-amd64 \
 	--amend anchore/test-images:$(NAME)-s390x-only \
 	--amend anchore/test-images:$(NAME)-arm64-only
-	docker push anchore/test-images:$(NAME)-no-amd64
+	docker manifest push anchore/test-images:$(NAME)-no-amd64
 
 .PHONY: clean
 clean: ## Remove images with the assigned tag for test_images

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -9,7 +9,6 @@ RED := $(shell tput -T linux setaf 1)
 RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
-BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 define title
     @printf '$(TITLE)$(1)$(RESET)\n'
@@ -37,10 +36,12 @@ push: build ## push built container to Docker Hub
 	anchore/test-images\:$(NAME)-no-arm64 \
 	--amend anchore/test-images\:$(NAME)-amd64-only \
 	--amend anchore/test-images\:$(NAME)-s390x-only
+	docker push anchore/test-images\:$(NAME)-no-arm64
 	docker manifest create \
 	anchore/test-images\:$(NAME)-no-amd64 \
 	--amend anchore/test-images\:$(NAME)-s390x-only \
 	--amend anchore/test-images\:$(NAME)-arm64-only
+	docker push anchore/test-images\:$(NAME)-no-amd64
 
 .PHONY: clean
 clean: ## Remove images with the assigned tag for test_images

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -9,6 +9,7 @@ RED := $(shell tput -T linux setaf 1)
 RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
+export BUILDX_NO_DEFAULT_ATTESTATIONS := 1
 
 define title
     @printf '$(TITLE)$(1)$(RESET)\n'

--- a/containers/multi-arch-stereoscope-tests/Makefile
+++ b/containers/multi-arch-stereoscope-tests/Makefile
@@ -1,0 +1,50 @@
+LAST_COMMIT := $(shell git rev-parse HEAD | cut -c 1-7)
+NAME := $(shell pwd | rev | cut -d '/' -f 1 | rev)-$(LAST_COMMIT)
+IMAGEDIRS = $(shell ls -d containers/* | cut -d '/' -f 2)
+BOLD := $(shell tput -T linux bold)
+PURPLE := $(shell tput -T linux setaf 5)
+GREEN := $(shell tput -T linux setaf 2)
+CYAN := $(shell tput -T linux setaf 6)
+RED := $(shell tput -T linux setaf 1)
+RESET := $(shell tput -T linux sgr0)
+TITLE := $(BOLD)$(PURPLE)
+SUCCESS := $(BOLD)$(GREEN)
+BUILDX_NO_DEFAULT_ATTESTATIONS=1
+
+define title
+    @printf '$(TITLE)$(1)$(RESET)\n'
+endef
+
+.PHONY: lint
+lint:
+	$(call title,Building container image anchore/test_image:$(NAME) variants)
+	docker run --rm -i hadolint/hadolint hadolint --ignore DL3033 - < Dockerfile
+
+.PHONY: build
+build:
+	$(call title,Building container image anchore/test_image:$(NAME) variants)
+	docker build -t anchore/test-images:$(NAME)-amd64-only --build-arg ARCH=linux/amd64 .
+	docker build -t anchore/test-images:$(NAME)-s390x-only --build-arg ARCH=linux/s390x .
+	docker build -t anchore/test-images:$(NAME)-arm64-only --build-arg ARCH=linux/arm64 .
+
+.PHONY: push
+push: build ## push built container to Docker Hub
+	$(call title,Pushing container image to docker hub anchore/test_image:$(NAME) variants)
+	docker push anchore/test-images:$(NAME)-amd64-only
+	docker push anchore/test-images:$(NAME)-s390x-only
+	docker push anchore/test-images:$(NAME)-arm64-only
+	docker manifest create \
+	anchore/test-images\:$(NAME)-no-arm64 \
+	--amend anchore/test-images\:$(NAME)-amd64-only \
+	--amend anchore/test-images\:$(NAME)-s390x-only
+	docker manifest create \
+	anchore/test-images\:$(NAME)-no-amd64 \
+	--amend anchore/test-images\:$(NAME)-s390x-only \
+	--amend anchore/test-images\:$(NAME)-arm64-only
+
+.PHONY: clean
+clean: ## Remove images with the assigned tag for test_images
+	$(call title,Removing image anchore/test_image:$(NAME) variants)
+	docker rmi anchore/test-images:$(NAME)-amd64-only
+	docker rmi anchore/test-images:$(NAME)-s390x-only
+	docker rmi anchore/test-images:$(NAME)-arm64-only

--- a/containers/multi-arch-stereoscope-tests/README.md
+++ b/containers/multi-arch-stereoscope-tests/README.md
@@ -1,0 +1,4 @@
+# `multi-arch-stereoscope-tests`
+
+Build mulit-arch manifests. Used in end to end tests on stereoscope's platform
+selection behavior.


### PR DESCRIPTION
In order to put end-to-end tests around stereoscope's platform selection behavior, we need multi-arch images that are missing specific platforms. Since we haven't found any, build these and host them at anchore/test_images.

## Notes

- I'm looking for feedback on this pattern, since this is the first multi-arch image here, and sort of a unique case
- to test `make push`, I ran `sed -i '' 's/anchore\/test-images/willmurphyscode\/multiarch-example/g' Makefile` and then ran `make push` from `./containers/multi-arch-stereoscope-tests`. The results are at https://hub.docker.com/repository/docker/willmurphyscode/multiarch-example/tags?page=1&ordering=last_updated
- Docker build with `--platform` works locally but fails in CI. Maybe there's a version mismatch?