### PR TITLE
chore: scoping context used for dockerhub push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,6 @@ workflows:
     jobs:
       - push:
           name: push_to_dockerhub
-          context: dockerhub
+          context: dockerhub-anchoredevwrite
           filters: *only_main_branch
 


### PR DESCRIPTION
In an effort to lock down our credentials and permissions in CI, we created various dockerhub and github accounts with different permissions.

This update uses a more restricted dockerhub account's username/pat and github token that only grants what is relevant.