### PR TITLE
Add newrelic jar, test cases for syft#2596

### DIFF
--- a/containers/java/java_artifact_urls.txt
+++ b/containers/java/java_artifact_urls.txt
@@ -1,3 +1,4 @@
+https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.8.0/newrelic-agent-8.8.0.jar
 https://get.jenkins.io/plugins/nomad/0.7.4/nomad.hpi
 https://get.jenkins.io/plugins/TwilioNotifier/0.2.1/TwilioNotifier.hpi
 https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-oldcore/15.3/xwiki-platform-oldcore-15.3.jar


### PR DESCRIPTION
To add regression tests for Syft#2596, where Syft incorrectly treated Newrelic jars for monitoring Spring as being part of Spring.

Adds test cases for anchore/syft#2596.