### PR TITLE
add azurelinux3 test image

### DIFF
--- a/containers/azurelinux3/Dockerfile
+++ b/containers/azurelinux3/Dockerfile
@@ -1,0 +1,3 @@
+FROM --platform=linux/amd64 azurelinuxpreview.azurecr.io/public/azurelinux/base/core@sha256:506cbf09eda568226e75d72b2ef9f537bb069624d92bfd8856ad5b2b29fbfb20
+
+RUN tdnf install -y python3-werkzeug-2.2.3-1.azl3 # esnure detection of CVE-2023-46136

--- a/containers/azurelinux3/Dockerfile
+++ b/containers/azurelinux3/Dockerfile
@@ -1,3 +1,3 @@
 FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core@sha256:506cbf09eda568226e75d72b2ef9f537bb069624d92bfd8856ad5b2b29fbfb20
 
-RUN tdnf install -y python3-werkzeug-2.2.3-1.azl3 # esnure detection of CVE-2023-46136
+RUN tdnf install -y kernel-6.6.22.1-1.azl3

--- a/containers/azurelinux3/Dockerfile
+++ b/containers/azurelinux3/Dockerfile
@@ -1,3 +1,3 @@
-FROM --platform=linux/amd64 azurelinuxpreview.azurecr.io/public/azurelinux/base/core@sha256:506cbf09eda568226e75d72b2ef9f537bb069624d92bfd8856ad5b2b29fbfb20
+FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core@sha256:506cbf09eda568226e75d72b2ef9f537bb069624d92bfd8856ad5b2b29fbfb20
 
 RUN tdnf install -y python3-werkzeug-2.2.3-1.azl3 # esnure detection of CVE-2023-46136

--- a/containers/azurelinux3/Makefile
+++ b/containers/azurelinux3/Makefile
@@ -1,0 +1,1 @@
+../../ContainerMakefile


### PR DESCRIPTION
To be used in grype/vunnel quality gates when they start supporting Azure Linux 3.

See anchore/grype#1829

Scanning with a grype and vunnel that include azure linux 3 PRs:

``` sh
go run ./cmd/grype -c ~/work/vunnel/.grype.yaml anchore/test_images:azurelinux3-39058ba
NAME    INSTALLED        FIXED-IN           TYPE  VULNERABILITY   SEVERITY 
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2024-26582  High      
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2024-1086   High      
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2015-5157   High      
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2013-2094   High      
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2024-26585  Medium    
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2023-52429  Medium    
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2018-20169  Medium    
kernel  6.6.22.1-1.azl3  0:6.6.22.1-2.azl3  rpm   CVE-2014-3185   Medium
```

This gives use several CVEs before the usual 2021 quality gate cutoff to use for testing vunnel/grype/grype-db against Azure Linux 3 feed. (Note that these vulnerabilities are against installing an intentionally outdated version of the kernel RPM.)