### PR TITLE
fix: move to non-preview Azure Linux 3 registry, choose better RPM

### DIFF
--- a/containers/azurelinux3/Dockerfile
+++ b/containers/azurelinux3/Dockerfile
@@ -1,3 +1,2 @@
-FROM azurelinuxpreview.azurecr.io/public/azurelinux/base/core@sha256:506cbf09eda568226e75d72b2ef9f537bb069624d92bfd8856ad5b2b29fbfb20
-
-RUN tdnf install -y kernel-6.6.22.1-1.azl3
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:9c1df3923b29a197dc5e6947e9c283ac71f33ef051110e3980c12e87a2de91f1
+RUN tdnf install -y golang-1.22.5-1.azl3


### PR DESCRIPTION
Previously, this image depended on the azurelinuxpreview container registry, which is incorrect since Azure Linux 3 is GA and moved to mcr.microsoft.com. Additionally, use a vulnerable package besides kernel headers, since matching on kernel headers in a container seems incorrect.

Part of anchore/grype#1829