### PR TITLE
fix: pin photon4 rpms

### DIFF
--- a/containers/photon4/Dockerfile
+++ b/containers/photon4/Dockerfile
@@ -1,12 +1,4 @@
-# Photon OS 4.0 test image with pinned vulnerable packages
-FROM photon:4.0
+# Photon OS 4.0 test image with known vulnerable packages
+# Pin base image by digest (4.0-20240728) to lock package versions
+FROM photon:4.0@sha256:88fccf9e63c2996b8d58ee506e0634def6aa20221ba367e2f63f3a39858de60e
 LABEL maintainer="Anchore Test"
-
-# Install specific vulnerable versions for testing
-# hadolint ignore=DL3041
-RUN tdnf install -y \
-    curl-8.12.0-1.ph4 \
-    curl-libs-8.12.0-1.ph4 \
-    expat-libs-2.7.1-1.ph4 \
-    openssl-3.0.16-2.ph4 \
-    && tdnf clean all

--- a/containers/photon4/Dockerfile
+++ b/containers/photon4/Dockerfile
@@ -1,7 +1,12 @@
-# Photon OS 4.0 test image
+# Photon OS 4.0 test image with pinned vulnerable packages
 FROM photon:4.0
 LABEL maintainer="Anchore Test"
-# Update image and install some packages with known vulnerabilities for testing
+
+# Install specific vulnerable versions for testing
 # hadolint ignore=DL3041
-RUN tdnf update -y && tdnf clean all
-RUN tdnf install -y curl vim && tdnf clean all
+RUN tdnf install -y \
+    curl-8.12.0-1.ph4 \
+    curl-libs-8.12.0-1.ph4 \
+    expat-libs-2.7.1-1.ph4 \
+    openssl-3.0.16-2.ph4 \
+    && tdnf clean all

--- a/containers/photon4/README.md
+++ b/containers/photon4/README.md
@@ -1,6 +1,14 @@
 # `photon4`
-VMware Photon OS 4.0 base image with some common packages installed.
+VMware Photon OS 4.0 base image with pinned vulnerable packages for testing.
 
 ## why?
 This image is used to test Photon OS vulnerability scanning support in grype.
 Photon OS uses tdnf (Tiny DNF) as its package manager and RPM packages.
+
+## Pinned vulnerable packages
+| Package     | Version      | CVEs                                              |
+|-------------|--------------|---------------------------------------------------|
+| curl        | 8.12.0-1.ph4 | CVE-2025-9086, CVE-2025-10148, CVE-2025-4947, CVE-2025-5025 |
+| curl-libs   | 8.12.0-1.ph4 | CVE-2025-9086, CVE-2025-10148, CVE-2025-4947, CVE-2025-5025 |
+| expat-libs  | 2.7.1-1.ph4  | CVE-2025-59375                                    |
+| openssl     | 3.0.16-2.ph4 | CVE-2025-9230                                     |

--- a/containers/photon4/README.md
+++ b/containers/photon4/README.md
@@ -1,14 +1,12 @@
 # `photon4`
-VMware Photon OS 4.0 base image with pinned vulnerable packages for testing.
+VMware Photon OS 4.0 base image with known vulnerable packages for testing.
 
 ## why?
 This image is used to test Photon OS vulnerability scanning support in grype.
 Photon OS uses tdnf (Tiny DNF) as its package manager and RPM packages.
 
-## Pinned vulnerable packages
-| Package     | Version      | CVEs                                              |
-|-------------|--------------|---------------------------------------------------|
-| curl        | 8.12.0-1.ph4 | CVE-2025-9086, CVE-2025-10148, CVE-2025-4947, CVE-2025-5025 |
-| curl-libs   | 8.12.0-1.ph4 | CVE-2025-9086, CVE-2025-10148, CVE-2025-4947, CVE-2025-5025 |
-| expat-libs  | 2.7.1-1.ph4  | CVE-2025-59375                                    |
-| openssl     | 3.0.16-2.ph4 | CVE-2025-9230                                     |
+## image pinning
+The base image is pinned by digest rather than installing specific package versions
+with tdnf. Photon OS repos only keep the latest version of each package, so pinning
+RPM versions in `tdnf install` breaks as soon as a newer version supersedes them.
+Pinning the base image digest locks all package versions reliably.


### PR DESCRIPTION
The RPM repos for photon only contain the latest package versions, so pin to an old tag of the whole image rather than try to pin individual RPMs. Build it into our test images in case the old tag goes away.